### PR TITLE
Fix `sanitize_id` leading character removal

### DIFF
--- a/src/bin/fasten_clean.rs
+++ b/src/bin/fasten_clean.rs
@@ -123,7 +123,7 @@ fn main(){
 
         if passed {
             for i in 0..trimmed_seqs.len() {
-                println!("{}\n{}\n+\n{}",
+                println!("@{}\n{}\n+\n{}",
                          &trimmed_ids[i],
                          &trimmed_seqs[i],
                          &trimmed_quals[i],

--- a/src/io/seq.rs
+++ b/src/io/seq.rs
@@ -25,6 +25,16 @@ fn test_cleanable() {
     assert!(cleanable.to_string() == "@MY_ID\nATNGG\n+\nAB!DE");
 }
 
+#[test]
+/// Test if a single leading `@` symbols in ID is stripped
+fn test_sanitize_id() {
+    assert_eq!(Seq::sanitize_id("@MY_ID"), "MY_ID");
+    // no change for id without leading `@`
+    assert_eq!(Seq::sanitize_id("MY_ID"), "MY_ID");
+    // should only strip one instance
+    assert_eq!(Seq::sanitize_id("@@MY_ID"), "@MY_ID");
+}
+
 
 /// A sequence struct that contains the ID, sequence, and quality cigar line
 #[derive(Debug)]

--- a/src/io/seq.rs
+++ b/src/io/seq.rs
@@ -26,13 +26,16 @@ fn test_cleanable() {
 }
 
 #[test]
-/// Test if a single leading `@` symbols in ID is stripped
+/// Test if a single leading `@` symbols and whitespaces in ID are stripped
 fn test_sanitize_id() {
     assert_eq!(Seq::sanitize_id("@MY_ID"), "MY_ID");
     // no change for id without leading `@`
     assert_eq!(Seq::sanitize_id("MY_ID"), "MY_ID");
     // should only strip one instance
     assert_eq!(Seq::sanitize_id("@@MY_ID"), "@MY_ID");
+    // should trim whitespaces
+    assert_eq!(Seq::sanitize_id("@MY_ID\n"), "MY_ID");
+    assert_eq!(Seq::sanitize_id("@\n\n  MY_ID  \n"), "MY_ID");
 }
 
 

--- a/src/io/seq.rs
+++ b/src/io/seq.rs
@@ -115,14 +115,7 @@ impl Cleanable for Seq {
     /// Read an identifier and return a cleaned version,
     /// e.g., removing @ in a fastq identifier.
     fn sanitize_id(id: &str) -> String {
-        if id.len() == 0 {
-            return String::new();
-        }
-        let mut id_copy = id.to_string();
-        if id_copy.chars().nth(0).expect("ID was empty") == '@' {
-            id_copy.pop();
-        }
-        return id_copy;
+        id.strip_prefix('@').unwrap_or(id).to_string()
     }
         
 

--- a/src/io/seq.rs
+++ b/src/io/seq.rs
@@ -125,7 +125,7 @@ impl Cleanable for Seq {
     /// Read an identifier and return a cleaned version,
     /// e.g., removing @ in a fastq identifier.
     fn sanitize_id(id: &str) -> String {
-        id.strip_prefix('@').unwrap_or(id).to_string()
+        id.strip_prefix('@').unwrap_or(id).trim().to_string()
     }
         
 


### PR DESCRIPTION
Changes:
- Uses the `strip_prefix` method to remove a single `@` symbol from the ID.
- Returns the ID as is if the prefix is absent.
- Removes leading and trailing whitespaces and newlines: correct behavior accidentally produced by `id_copy.pop()`.
- Prints the missing `@` symbol in `fasten_clean` now that the IDs no longer have the original `@`.
- Adds tests to prevent future regressions.