### PR TITLE
Fasten clean: iterate directly over string bytes

### DIFF
--- a/src/bin/fasten_clean.rs
+++ b/src/bin/fasten_clean.rs
@@ -150,28 +150,15 @@ fn avg_quality(qual: &str) -> f32 {
 
 /// Trim the ends of reads with low quality
 fn trim(seq: &String, qual: &String, min_qual: u8) -> (String,String) {
-    let mut trim5 :usize=0;
-    let mut trim3 :usize=qual.len();
-
     let offset_min_qual = min_qual + 33;
+    let qual_bytes = qual.as_bytes();
     
     // 5'
-    for qual in qual.chars(){
-        if (qual as u8) < offset_min_qual {
-            trim5+=1;
-        } else {
-            break;
-        }
-    }
-
+    let trim5 = qual_bytes.iter().position(|&q| q >= offset_min_qual).unwrap_or(0);
     // 3'
-    for qual in qual.chars().rev() {
-        if (qual as u8) < offset_min_qual {
-            trim3-=1;
-        } else {
-            break;
-        }
-    }
+    let trim3 = qual_bytes
+        .iter()
+        .rposition(|&q| q >= offset_min_qual).unwrap_or(qual_bytes.len() - 1) + 1;
 
     let new_seq :String;
     let new_qual:String;

--- a/src/bin/fasten_clean.rs
+++ b/src/bin/fasten_clean.rs
@@ -142,11 +142,8 @@ fn main(){
 
 /// Determine average quality of a qual cigar string,
 /// e.g., let q:f32 = avg_quality("AABC!...")
-fn avg_quality(qual: &String) -> f32 {
-    let mut total :u32 = 0;
-    for qual_char in qual.chars() {
-        total += qual_char as u8 as u32;
-    }
+fn avg_quality(qual: &str) -> f32 {
+    let total :u32 = qual.as_bytes().iter().map(|&qual_char| qual_char as u32).sum();
     let avg = (total as f32 / qual.len() as f32) - 33.0;
     return avg;
 }


### PR DESCRIPTION
Changes:
- Iterates over the the raw bytes of the quality string to avoid overhead in functions:
  - `trim`
  - `avg_quality`

See https://doc.rust-lang.org/src/core/str/iter.rs.html#42 for details of the overhead caused by the `Chars` iterator.